### PR TITLE
FrontendController Fix

### DIFF
--- a/src/main/java/edu/ucsb/cs156/team02/controllers/FrontendController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/FrontendController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.team02.controllers;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -11,4 +12,10 @@ public class FrontendController {
   public String index() {
     return "forward:/index.html";
   }
+
+  @GetMapping("/csrf")
+  public ResponseEntity<String> csrf() {
+      return ResponseEntity.notFound().build();
+  }
+
 }


### PR DESCRIPTION
# Overview

Resolved issues with Heroku deployment, borrowed from [demo-spring-react-example-v2](https://github.com/ucsb-cs156-w22/demo-spring-react-example-v2)

"Swagger was not working on Heroku with POST and other methods requiring a CSRF token, because swagger was doing a GET request on /csrf and it was getting back HTML for the React Single Page Application and choking because it was expecting JSON.

In this PR, we explicitly map a GET on the /csrf endpoint to return a 404, which apparently leaves Swagger happy."

